### PR TITLE
Atualização da Aula 04 para JUnit 5

### DIFF
--- a/aula4/fga0242/Calculadora.java
+++ b/aula4/fga0242/Calculadora.java
@@ -1,41 +1,26 @@
 
 package fga0242;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+public class Calculadora {
 
-public class TesteSubtracaoSimples {
+	private int op1;
+	private int op2;
+	private int resultado;
 
-	Calculadora c; 
-	
-	@BeforeEach
-	public void setup() {
-		c = new Calculadora();
+	public int subtracao(int op1, int op2) {
+		this.op1 = op1; 
+		this.op2 = op2;
+		this.resultado = op1 - op2; 
+		
+		return this.resultado;
 	}
-	
-	@Test
-	public void test1() { //3-2
-		assertEquals(1, c.subtracao(3,2));
+
+	public int soma(int op1, int op2) {
+		this.op1 = op1; 
+		this.op2 = op2; 
+		this.resultado = op1 + op2;
+		
+		return this.resultado;
 	}
-	
-	@Test
-	public void test2() { //2-3
-		assertEquals(-1, c.subtracao(2,3));
-	}
-	
-	@Test
-	public void test3() { //3-(-2)
-		assertEquals(5, c.subtracao(3,-2));
-	}
-	
-	@Test
-	public void test4() { //2-(-3)
-		assertEquals(5, c.subtracao(2,-3));
-	}
-	
-	@Test
-	public void test5() { //-3-(-2)
-		assertEquals(-1, c.subtracao(-3,-2));
-	}
+
 }

--- a/aula4/fga0242/Calculadora.java
+++ b/aula4/fga0242/Calculadora.java
@@ -1,26 +1,41 @@
 
 package fga0242;
 
-public class Calculadora {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-	private int op1;
-	private int op2;
-	private int resultado;
+public class TesteSubtracaoSimples {
 
-	public int subtracao(int op1, int op2) {
-		this.op1 = op1; 
-		this.op2 = op2;
-		this.resultado = op1 - op2; 
-		
-		return this.resultado;
+	Calculadora c; 
+	
+	@BeforeEach
+	public void setup() {
+		c = new Calculadora();
 	}
-
-	public int soma(int op1, int op2) {
-		this.op1 = op1; 
-		this.op2 = op2; 
-		this.resultado = op1 + op2;
-		
-		return this.resultado;
+	
+	@Test
+	public void test1() { //3-2
+		assertEquals(1, c.subtracao(3,2));
 	}
-
+	
+	@Test
+	public void test2() { //2-3
+		assertEquals(-1, c.subtracao(2,3));
+	}
+	
+	@Test
+	public void test3() { //3-(-2)
+		assertEquals(5, c.subtracao(3,-2));
+	}
+	
+	@Test
+	public void test4() { //2-(-3)
+		assertEquals(5, c.subtracao(2,-3));
+	}
+	
+	@Test
+	public void test5() { //-3-(-2)
+		assertEquals(-1, c.subtracao(-3,-2));
+	}
 }

--- a/aula4/fga0242/TesteSubtracaoParametrizado.java
+++ b/aula4/fga0242/TesteSubtracaoParametrizado.java
@@ -1,74 +1,53 @@
 
 package fga0242;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
+import java.util.stream.Stream;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TesteSubtracaoParametrizado {
 
-	//Atributos do objeto de teste: cada teste terá seu valor associado
-	private int op1;
-	private int op2;
-	private int rstEspSub;
-	private int rstEspSoma; 
-
+	// Passo 0: definição do objeto em teste
 	private Calculadora c;
 	
-	@Before
+	/* Passo 1: definição anterior a cada caso de teste, @BeforeEach substitui 
+	o antigo @Before e executa antes de cada execução parametrizada */
+	@BeforeEach
 	public void setup() {
 		c = new Calculadora();
 	}
 	
-	//1a. coisa a ser feita: metodo que retorna conjunto de parametros
-	@Parameters
-	public static Iterable<Object[]> getParameters() {
-		Object[][] parametros = new Object[][] {
-			{3, 2, 1, 5},
-			{2, 3, -1, 5}, 
-			{3, -2, 5, 1}, 
-			{2, -3, 5, -1}, 
-			{-3, -2, -1, -5},
-			{-2, -3, 1, -5}, 
-			{0, 3, -3, 3}
-		};
-		return Arrays.asList(parametros);
+	// Passo 2: definição de metodo que retorna conjunto de parametros, futuramente associados a @MethodSource nos testes
+	// Formato: op1, op2, resultadoEsperadoSub, resultadoEsperadoSoma
+	private static Stream<Arguments> parametros() {
+		return Stream.of(
+			Arguments.of( 3,  2,  1,  5),
+			Arguments.of( 2,  3, -1,  5),
+			Arguments.of( 3, -2,  5,  1),
+			Arguments.of( 2, -3,  5, -1),
+			Arguments.of(-3, -2, -1, -5),
+			Arguments.of(-2, -3,  1, -5),
+			Arguments.of( 0,  3, -3,  3)
+        	);
 	}
 
-	//2o passo: criar o construtor alternativo do objeto de teste
-	public TesteSubtracaoParametrizado(int op1, int op2, int rstEspSub, int rstEspSoma) {
-		this.op1 = op1; 
-		this.op2 = op2;
-		this.rstEspSub = rstEspSub;
-		this.rstEspSoma = rstEspSoma;
-	}
-	
-	
-	//3o passo: escrever o teste!
-	@Test
-	public void testSubtracao() {
-		assertEquals(rstEspSub, c.subtracao(op1, op2));
-	}
-	
-	
-	@Test
-	public void testSoma() {
-		assertEquals(rstEspSoma, c.soma(op1, op2));
+	// Passo 3: escrever os testes!
+	@ParameterizedTest(name = "#{index} => {0} - {1} = {2}") // #num_do_teste => op1 - op2 = resultadoEsperadoSub
+    	@MethodSource("parametros")
+	public void testSubtracao(int op1, int op2, int resultadoEsperadoSub, int resultadoEsperadoSoma) {
+		assertEquals(resultadoEsperadoSub, c.subtracao(op1, op2));
 	}
 
-	
-	
-	
-	
-	
-	
-	
+
+	@ParameterizedTest(name = "#{index} => {0} + {1} = {3}") // #num_do_teste => op1 + op2 = resultadoEsperadoSoma
+	@MethodSource("parametros")
+	void testSoma(int op1, int op2, int resultadoEsperadoSub, int resultadoEsperadoSoma) {
+		assertEquals(resultadoEsperadoSoma, c.soma(op1, op2));
+	}
 	
 }

--- a/aula4/fga0242/TesteSubtracaoSimples.java
+++ b/aula4/fga0242/TesteSubtracaoSimples.java
@@ -1,17 +1,16 @@
 
 package fga0242;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TesteSubtracaoSimples {
 
 	Calculadora c; 
 	
-	@Before
+	@BeforeEach
 	public void setup() {
 		c = new Calculadora();
 	}
@@ -41,7 +40,5 @@ public class TesteSubtracaoSimples {
 	public void test5() { //-3-(-2)
 		assertEquals(-1, c.subtracao(-3,-2));
 	}
-	
-
 
 }


### PR DESCRIPTION
Tive dificuldades em rodar os testes porque o JUnit mudou a forma de declarar anotações e modulizar dependências a partir da versão 5, e os códigos seguem o padrão do JUnit 4. Para garantir que a suíte de testes continue funcionando (e tirar proveito dos novos recursos), fiz a atualização dos códigos da aula 04.

Se acharem útil, posso aplicar a mesma migração às demais pastas de aulas em um próximo PR.